### PR TITLE
Removing custom ports when launching projects

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,10 +13,7 @@
             "args": [],
             "cwd": "${workspaceFolder}/src/EdFi.Roster.Explorer",
             "console": "internalConsole",
-            "stopAtEntry": false,
-            "env": {
-                "ASPNETCORE_URLS": "http://localhost:5001"
-            }
+            "stopAtEntry": false
         },
         {
             "name": "ChangeQueries",
@@ -27,10 +24,7 @@
             "args": [],
             "cwd": "${workspaceFolder}/src/EdFi.Roster.ChangeQueries",
             "console": "internalConsole",
-            "stopAtEntry": false,
-            "env": {
-                "ASPNETCORE_URLS": "http://localhost:5002"
-            }
+            "stopAtEntry": false
         }
     ]
 }


### PR DESCRIPTION
Previously, the configuration had custom ports to allow to launch both projects at the same time. Since this is not mandatory (and unlikely) the additional configuration is not needed and may be misleading in the documentation